### PR TITLE
Fix plugin build glob and add packaging script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Run tests
+        run: dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --verbosity normal
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -29,23 +32,8 @@ jobs:
             '.version_number = $v' manifest.json > manifest.tmp \
             && mv manifest.tmp manifest.json
 
-      - name: Build
-        run: dotnet build AutoFeed.csproj -c Release
-
-      - name: Run tests
-        run: dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --no-restore --verbosity normal
-
-      - name: Package for Thunderstore
-        run: |
-          mkdir thunderstore
-          cp manifest.json thunderstore/
-          cp icon.png thunderstore/
-          cp README.md thunderstore/
-          cp AutoFeed/bin/Release/net48/Narolith.AutoFeed.dll thunderstore/
-          cd thunderstore && zip -r "../AutoFeed-${{ steps.version.outputs.version }}.zip" .
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: AutoFeed-${{ steps.version.outputs.version }}.zip
+          files: manifest.json
           body_path: CHANGELOG.md

--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -12,6 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="AutoFeed.Core\**" />
+    <Compile Remove="AutoFeed.Tests\**" />
+    <EmbeddedResource Remove="AutoFeed.Core\**" />
+    <EmbeddedResource Remove="AutoFeed.Tests\**" />
+    <None Remove="AutoFeed.Core\**" />
+    <None Remove="AutoFeed.Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />

--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read version from csproj
+VERSION=$(grep -oP '(?<=<Version>)[^<]+' AutoFeed.csproj)
+ZIP="AutoFeed-${VERSION}.zip"
+
+echo "Building AutoFeed v${VERSION}..."
+dotnet build AutoFeed.csproj -c Release
+
+echo "Packaging..."
+STAGING=$(mktemp -d)
+cp manifest.json "$STAGING/"
+cp icon.png "$STAGING/"
+cp README.md "$STAGING/"
+cp "bin/Release/net48/Narolith.AutoFeed.dll" "$STAGING/"
+
+(cd "$STAGING" && zip -r "$OLDPWD/$ZIP" .)
+rm -rf "$STAGING"
+
+echo "Done: $ZIP"


### PR DESCRIPTION
## Summary
- Excludes `AutoFeed.Core` and `AutoFeed.Tests` subdirectories from `AutoFeed.csproj` glob — fixes duplicate attribute errors and xunit references bleeding into the plugin build
- Removes plugin build step from release workflow (requires Valheim game DLLs not available in CI)
- Adds `Scripts/package.sh` to build and zip the Thunderstore package locally

## Test Plan
- [ ] `dotnet build AutoFeed.csproj -c Release` completes without errors
- [ ] `./Scripts/package.sh` produces a valid zip containing `manifest.json`, `icon.png`, `README.md`, `Narolith.AutoFeed.dll`
- [ ] After merge, tag `v0.2.5` to verify release workflow creates the GitHub Release successfully