### PR TITLE
Opt into Node.js 24 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the release job to silence the Node.js 20 deprecation warning from `softprops/action-gh-release@v2`
- No v3 of that action exists yet; this opts in early ahead of the June 2026 forced cutover