### PR TITLE
Fix release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,14 @@ jobs:
             '.version_number = $v' manifest.json > manifest.tmp \
             && mv manifest.tmp manifest.json
 
+      - name: Extract release notes
+        id: notes
+        run: |
+          awk "/^## ${{ steps.version.outputs.version }}/{found=1; next} found && /^## /{exit} found{print}" \
+            CHANGELOG.md > release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: manifest.json
-          body_path: CHANGELOG.md
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
+## 0.2.5
+
+- Fixed plugin build glob excluding sibling projects (AutoFeed.Core, AutoFeed.Tests)
+- Removed plugin build step from release workflow (requires Valheim game DLLs unavailable in CI)
+- Added `Scripts/package.sh` to build and zip the Thunderstore package locally
+- Bumped GitHub Actions to Node.js 24
+
+## 0.2.4
+
+- Replaced prebuild PowerShell manifest sync script with a release workflow
+- Added automated CI tests via GitHub Actions
+- Added branch protection requiring tests to pass before merging to main
+
 ## 0.2.3
 
 - Added missing Thunderstore dependency to Jotunn
 - Added manifest version script to avoid mismatch versions
-
-<details>
-<summary>Click to expand previous changes</summary>
 
 ## 0.2.2
 
@@ -23,7 +33,7 @@
 
 ## 0.1.0
 
-- Added Jotunn for for reference and assembly handling
+- Added Jotunn for reference and assembly handling
 - Code readability updates
 - Added more details to README
 - Increased default range from 5 to 10
@@ -33,5 +43,3 @@
 ## 0.0.2
 
 - Updated GitHub link
-
-</details>


### PR DESCRIPTION
Adds v0.2.4 and v0.2.5 changelog entries and updates the release workflow to extract only the current version's section instead of dumping the full changelog.