### PR TITLE
Make mod server-side only

### DIFF
--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Narolith.AutoFeed</AssemblyName>
     <Title>Auto Feed</Title>
     <Description>Valheim mod to auto feed animals from a nearby chest</Description>
-    <Version>0.2.5</Version>
+    <Version>0.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Mod is now server-side only — install on the server, clients no longer need it
+- Feeding logic now only executes on the server, preventing double-feeding in multiplayer
+
 ## 0.2.5
 
 - Fixed plugin build glob excluding sibling projects (AutoFeed.Core, AutoFeed.Tests)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -3,7 +3,7 @@ namespace AutoFeed;
 [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 [BepInDependency(Jotunn.Main.ModGuid)]
 [Jotunn.Utils.NetworkCompatibility(
-    Jotunn.Utils.CompatibilityLevel.EveryoneMustHaveMod,
+    Jotunn.Utils.CompatibilityLevel.ServerMustHaveMod,
     Jotunn.Utils.VersionStrictness.Minor
 )]
 public class Plugin : BaseUnityPlugin
@@ -59,7 +59,8 @@ public class Plugin : BaseUnityPlugin
             bool IsTamedAndHungry() => ___m_tamable is not null && ___m_tamable.IsHungry();
 
             if (
-                !ModEnabled()
+                !ZNet.instance.IsServer()
+                || !ModEnabled()
                 || !HasCharacterData()
                 || !IsTamedAndHungry()
                 || !HasValidFoodTypes()


### PR DESCRIPTION
## Summary
- Adds `ZNet.instance.IsServer()` guard to the Postfix patch — feeding logic only executes on the server
- Changes `NetworkCompatibility` from `EveryoneMustHaveMod` to `ServerMustHaveMod` — clients no longer need the mod installed
- Prevents double-feeding that would occur if both the server and clients had the mod installed

## Test Plan
- [ ] Install on dedicated server only, verify animals are fed from nearby chests
- [ ] Confirm clients without the mod see the eat animation and inventory changes synced correctly
- [ ] Confirm no double-feeding occurs when a client also has the mod installed