### PR TITLE
Fix manifest version sync in packaging script

### DIFF
--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -10,7 +10,7 @@ dotnet build AutoFeed.csproj -c Release
 
 echo "Packaging..."
 STAGING=$(mktemp -d)
-cp manifest.json "$STAGING/"
+jq --arg v "$VERSION" '.version_number = $v' manifest.json > "$STAGING/manifest.json"
 cp icon.png "$STAGING/"
 cp README.md "$STAGING/"
 cp "bin/Release/net48/Narolith.AutoFeed.dll" "$STAGING/"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AutoFeed",
-  "version_number": "0.2.3",
+  "version_number": "0.3.0",
   "website_url": "https://github.com/stephen-cherry/autofeed",
   "description": "This mod will automatically feed tameable creatures in the game with food from nearby chests.",
   "dependencies": ["ValheimModding-Jotunn-2.20.1"]


### PR DESCRIPTION
Packaging script now patches manifest.json version from the csproj at package time, so the zip always has the correct version regardless of the local manifest state.