### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run tests
         run: dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --verbosity normal
 
+      - name: Build
+        run: dotnet build AutoFeed.csproj --configuration Release
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -40,8 +43,19 @@ jobs:
           awk "/^## ${{ steps.version.outputs.version }}/{found=1; next} found && /^## /{exit} found{print}" \
             CHANGELOG.md > release-notes.md
 
+      - name: Package for Thunderstore
+        run: |
+          mkdir -p thunderstore
+          cp bin/Release/net48/Narolith.AutoFeed.dll thunderstore/
+          cp manifest.json thunderstore/
+          cp icon.png thunderstore/
+          cp README.md thunderstore/
+          cd thunderstore && zip -r ../AutoFeed-${{ steps.version.outputs.version }}.zip .
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: manifest.json
+          files: |
+            AutoFeed-${{ steps.version.outputs.version }}.zip
+            manifest.json
           body_path: release-notes.md

--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Narolith.AutoFeed</AssemblyName>
     <Title>Auto Feed</Title>
     <Description>Valheim mod to auto feed animals from a nearby chest</Description>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="AutoFeed.Core\AutoFeed.Core.csproj" />
+    <Compile Include="AutoFeed.Core\FeedingLogic.cs" />
   </ItemGroup>
+
 </Project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Fixed animals not feeding from chests — AutoFeed.Core.dll was missing from the Thunderstore package; FeedingLogic is now compiled directly into the main DLL so only one file needs to be shipped
+
 ## 0.3.1
 
 - Updated README with server-side installation instructions and configuration table


### PR DESCRIPTION
## Summary
- Fixed animals not feeding from chests — `AutoFeed.Core.dll` was missing from the Thunderstore package
- `FeedingLogic.cs` is now compiled directly into `Narolith.AutoFeed.dll` via a `Compile Include`, eliminating the separate assembly entirely
- Updated release workflow to build the project and produce a Thunderstore-ready zip as a GitHub Release artifact

## Test plan
- [ ] Confirm all 12 unit tests pass
- [ ] Confirm only `Narolith.AutoFeed.dll` appears in build output (no `AutoFeed.Core.dll`)
- [ ] Deploy to server and confirm animals feed from nearby chests

🤖 Generated with [Claude Code](https://claude.com/claude-code)