### PR TITLE
Fix release workflow: remove CI build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Run tests
         run: dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --verbosity normal
 
-      - name: Build
-        run: dotnet build AutoFeed.csproj --configuration Release
-
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -43,19 +40,8 @@ jobs:
           awk "/^## ${{ steps.version.outputs.version }}/{found=1; next} found && /^## /{exit} found{print}" \
             CHANGELOG.md > release-notes.md
 
-      - name: Package for Thunderstore
-        run: |
-          mkdir -p thunderstore
-          cp bin/Release/net48/Narolith.AutoFeed.dll thunderstore/
-          cp manifest.json thunderstore/
-          cp icon.png thunderstore/
-          cp README.md thunderstore/
-          cd thunderstore && zip -r ../AutoFeed-${{ steps.version.outputs.version }}.zip .
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            AutoFeed-${{ steps.version.outputs.version }}.zip
-            manifest.json
+          files: manifest.json
           body_path: release-notes.md


### PR DESCRIPTION
## Summary
- Removes the build step added in #12 — CI doesn't have Valheim game DLLs so the build always fails
- Use `Scripts/package.sh` locally to build and produce the Thunderstore zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)