### PR TITLE
perf: frame drop fixes + bump 1.0.1

### DIFF
--- a/AutoFeed.Core/FeedingLogic.cs
+++ b/AutoFeed.Core/FeedingLogic.cs
@@ -7,6 +7,7 @@ public static class FeedingLogic
     /// <summary>
     /// Returns the name of the first inventory item that matches a consumable,
     /// or null if none found.
+    /// Retained for unit test support — production feeding logic uses direct dictionary lookup.
     /// </summary>
     public static string? FindConsumableInInventory(
         IEnumerable<string> inventoryItemNames,

--- a/AutoFeed.Core/FeedingLogic.cs
+++ b/AutoFeed.Core/FeedingLogic.cs
@@ -45,4 +45,10 @@ public static class FeedingLogic
             return false;
         return itemCount > 0;
     }
+
+    /// <summary>
+    /// Returns true if the cached value is still within the TTL window.
+    /// </summary>
+    public static bool IsCacheValid(float cachedTimestamp, float currentTime, float ttl) =>
+        currentTime - cachedTimestamp < ttl;
 }

--- a/AutoFeed.Tests/FeedingLogicTests.cs
+++ b/AutoFeed.Tests/FeedingLogicTests.cs
@@ -123,4 +123,30 @@ public class FeedingLogicTests
     {
         Assert.True(FeedingLogic.IsEligibleContainer("Cart", 5, ""));
     }
+
+    // --- IsCacheValid ---
+
+    [Fact]
+    public void IsCacheValid_ReturnsTrue_WhenWithinTtl()
+    {
+        Assert.True(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 4.9f, ttl: 5f));
+    }
+
+    [Fact]
+    public void IsCacheValid_ReturnsFalse_WhenTtlExpired()
+    {
+        Assert.False(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 5.1f, ttl: 5f));
+    }
+
+    [Fact]
+    public void IsCacheValid_ReturnsFalse_WhenExactlyAtBoundary()
+    {
+        Assert.False(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 5f, ttl: 5f));
+    }
+
+    [Fact]
+    public void IsCacheValid_ReturnsTrue_WhenCachedJustNow()
+    {
+        Assert.True(FeedingLogic.IsCacheValid(cachedTimestamp: 10f, currentTime: 10f, ttl: 5f));
+    }
 }

--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Narolith.AutoFeed</AssemblyName>
     <Title>Auto Feed</Title>
     <Description>Valheim mod to auto feed animals from a nearby chest</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.1
+
+- Performance: container scan results are now cached per animal (configurable TTL, default 5s), eliminating the full `Piece.s_allPieces` scan on every AI tick
+- Performance: distance calculations in container sorting now use `sqrMagnitude` instead of `Vector3.Distance`, removing redundant square root operations
+- Performance: consumable lookup structure is now built once per feed attempt instead of once per container scanned, reducing GC pressure
+- Fixed: `MissingReferenceException` when a cached container is destroyed during its TTL window
+- Added `Container Cache TTL` config option (default `5`)
+
 ## 1.0.0
 
 - Mod is now client and server side — all connected clients must have the mod installed

--- a/Extensions/ContainerExtensions.cs
+++ b/Extensions/ContainerExtensions.cs
@@ -4,27 +4,15 @@ public static class ContainerExtensions
 {
     public static bool ContainersContainItemFromList(
         this List<Container> containers,
-        List<ItemDrop> itemDrops,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
         out Container? targetContainer,
         out ItemDrop.ItemData? targetItem
     ) =>
-        FindItemInContainers(
-            containers,
-            CreateItemDictionary(itemDrops),
-            out targetContainer,
-            out targetItem
-        );
-
-    private static Dictionary<string, List<ItemDrop.ItemData>> CreateItemDictionary(
-        List<ItemDrop> itemDrops
-    ) =>
-        itemDrops
-            .GroupBy(i => i.m_itemData.m_shared.m_name)
-            .ToDictionary(g => g.Key, g => g.Select(i => i.m_itemData).ToList());
+        FindItemInContainers(containers, consumableMap, out targetContainer, out targetItem);
 
     private static bool FindItemInContainers(
         List<Container> containers,
-        Dictionary<string, List<ItemDrop.ItemData>> itemDropDict,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
         out Container? targetContainer,
         out ItemDrop.ItemData? targetItem
     )
@@ -32,7 +20,7 @@ public static class ContainerExtensions
         foreach (var container in containers)
         {
             var items = container.GetInventory().GetAllItems();
-            if (TryFindMatchingItem(items, itemDropDict, out targetItem))
+            if (TryFindMatchingItem(items, consumableMap, out targetItem))
             {
                 targetContainer = container;
                 return true;
@@ -46,22 +34,16 @@ public static class ContainerExtensions
 
     private static bool TryFindMatchingItem(
         List<ItemDrop.ItemData> items,
-        Dictionary<string, List<ItemDrop.ItemData>> itemDropDict,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
         out ItemDrop.ItemData? targetItem
     )
     {
-        var consumableNames = new HashSet<string>(itemDropDict.Keys);
-        var match = FeedingLogic.FindConsumableInInventory(
-            items.Select(i => i.m_shared.m_name),
-            consumableNames
-        );
-
-        if (match is not null)
-        {
-            targetItem = itemDropDict[match].First();
-            return true;
-        }
-
+        foreach (var item in items)
+            if (consumableMap.TryGetValue(item.m_shared.m_name, out var match))
+            {
+                targetItem = match;
+                return true;
+            }
         targetItem = null;
         return false;
     }

--- a/Extensions/Vector3Extensions.cs
+++ b/Extensions/Vector3Extensions.cs
@@ -2,8 +2,12 @@ namespace AutoFeed;
 
 public static class Vector3Extensions
 {
-    public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange)
+    public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange, int animalId, float currentTime)
     {
+        if (Plugin.ContainerCache.TryGetValue(animalId, out var entry)
+            && FeedingLogic.IsCacheValid(entry.timestamp, currentTime, Plugin.CacheTtl.Value))
+            return entry.containers;
+
         var sqrRadius = radiusRange * radiusRange;
         var result = new List<Container>();
         foreach (var piece in Piece.s_allPieces)
@@ -22,6 +26,7 @@ public static class Vector3Extensions
             .Select(x => x.container)
             .ToList();
 
+        Plugin.ContainerCache[animalId] = (currentTime, sorted);
         return sorted;
     }
 

--- a/Extensions/Vector3Extensions.cs
+++ b/Extensions/Vector3Extensions.cs
@@ -6,7 +6,10 @@ public static class Vector3Extensions
     {
         if (Plugin.ContainerCache.TryGetValue(animalId, out var entry)
             && FeedingLogic.IsCacheValid(entry.timestamp, currentTime, Plugin.CacheTtl.Value))
+        {
+            entry.containers.RemoveAll(c => c == null);
             return entry.containers;
+        }
 
         var sqrRadius = radiusRange * radiusRange;
         var result = new List<Container>();

--- a/Extensions/Vector3Extensions.cs
+++ b/Extensions/Vector3Extensions.cs
@@ -4,18 +4,25 @@ public static class Vector3Extensions
 {
     public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange)
     {
+        var sqrRadius = radiusRange * radiusRange;
         var result = new List<Container>();
         foreach (var piece in Piece.s_allPieces)
         {
             if (piece == null) continue;
             var container = piece.GetComponent<Container>();
             if (container == null) continue;
-            var dist = Vector3.Distance(piece.transform.position, center);
-            if (dist <= radiusRange && IsValidZNetView(container.GetComponent<ZNetView>()) && IsEligibleContainer(container))
+            var sqrDist = (piece.transform.position - center).sqrMagnitude;
+            if (sqrDist <= sqrRadius && IsValidZNetView(container.GetComponent<ZNetView>()) && IsEligibleContainer(container))
                 result.Add(container);
         }
-        result.Sort((a, b) => Vector3.Distance(a.transform.position, center).CompareTo(Vector3.Distance(b.transform.position, center)));
-        return result;
+
+        var sorted = result
+            .Select(c => (container: c, sqrDist: (c.transform.position - center).sqrMagnitude))
+            .OrderBy(x => x.sqrDist)
+            .Select(x => x.container)
+            .ToList();
+
+        return sorted;
     }
 
     private static bool IsValidZNetView(ZNetView? zNetView) =>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -12,10 +12,12 @@ public class Plugin : BaseUnityPlugin
     private static Harmony? _harmony;
 
     public static readonly Dictionary<int, float> LastFeedTimes = new();
+    internal static readonly Dictionary<int, (float timestamp, List<Container> containers)> ContainerCache = new();
 
     public static ConfigEntry<float> ContainerRange = default!;
     public static ConfigEntry<bool> ModEnabled = default!;
     public static ConfigEntry<string> ChestPrefix = default!;
+    public static ConfigEntry<float> CacheTtl = default!;
 
     private void Awake()
     {
@@ -34,6 +36,12 @@ public class Plugin : BaseUnityPlugin
             "Chest Prefix",
             "piece_chest",
             "Name prefix for containers eligible for auto-feeding. Leave empty to allow all containers."
+        );
+        CacheTtl = Config.Bind(
+            "General",
+            "Container Cache TTL",
+            5f,
+            "Seconds before the nearby-container list is refreshed for each animal."
         );
 
         _harmony = Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), null);
@@ -74,7 +82,7 @@ public class Plugin : BaseUnityPlugin
 
             var nearbyContainers =
                 ___m_character.gameObject.transform.position.GetContainersInRange(
-                    ContainerRange.Value
+                    ContainerRange.Value, animalId, Time.time
                 );
 
             var foundContainerWithFood = nearbyContainers.ContainersContainItemFromList(

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -80,13 +80,16 @@ public class Plugin : BaseUnityPlugin
             if (!FeedingLogic.ShouldFeed(animalId, Time.time, Plugin.LastFeedTimes, PluginSettings.FeedInterval))
                 return;
 
+            var consumableMap = ___m_consumeItems
+                .ToDictionary(i => i.m_itemData.m_shared.m_name, i => i.m_itemData);
+
             var nearbyContainers =
                 ___m_character.gameObject.transform.position.GetContainersInRange(
                     ContainerRange.Value, animalId, Time.time
                 );
 
             var foundContainerWithFood = nearbyContainers.ContainersContainItemFromList(
-                ___m_consumeItems,
+                consumableMap,
                 out var container,
                 out var item
             );

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -80,8 +80,9 @@ public class Plugin : BaseUnityPlugin
             if (!FeedingLogic.ShouldFeed(animalId, Time.time, Plugin.LastFeedTimes, PluginSettings.FeedInterval))
                 return;
 
-            var consumableMap = ___m_consumeItems
-                .ToDictionary(i => i.m_itemData.m_shared.m_name, i => i.m_itemData);
+            var consumableMap = new Dictionary<string, ItemDrop.ItemData>();
+            foreach (var drop in ___m_consumeItems)
+                consumableMap.TryAdd(drop.m_itemData.m_shared.m_name, drop.m_itemData);
 
             var nearbyContainers =
                 ___m_character.gameObject.transform.position.GetContainersInRange(

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -82,7 +82,11 @@ public class Plugin : BaseUnityPlugin
 
             var consumableMap = new Dictionary<string, ItemDrop.ItemData>();
             foreach (var drop in ___m_consumeItems)
-                consumableMap.TryAdd(drop.m_itemData.m_shared.m_name, drop.m_itemData);
+            {
+                var name = drop.m_itemData.m_shared.m_name;
+                if (!consumableMap.ContainsKey(name))
+                    consumableMap[name] = drop.m_itemData;
+            }
 
             var nearbyContainers =
                 ___m_character.gameObject.transform.position.GetContainersInRange(

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration is generated at `BepInEx/config/Narolith.AutoFeed.cfg` on first ru
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | Container Range | `10` | Radius (units) in which creatures search for food containers. |
+| Container Cache TTL | `5` | Seconds before the nearby-container list is refreshed for each animal. |
 | Chest Prefix | `piece_chest` | Only containers whose name starts with this prefix are eligible. Leave empty to allow all containers. |
 | Enabled | `true` | Enable or disable the mod. |
 

--- a/docs/superpowers/plans/2026-04-01-performance-fixes.md
+++ b/docs/superpowers/plans/2026-04-01-performance-fixes.md
@@ -1,0 +1,436 @@
+# AutoFeed Performance Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate three frame-drop hotspots in the `UpdateConsumeItem` Harmony postfix: per-tick world piece scanning, redundant sqrt calls in sort, and per-container heap allocations.
+
+**Architecture:** Fix 1 adds a per-animal container cache (TTL-based) so the expensive `Piece.s_allPieces` scan only runs every 5s per animal instead of every tick. Fix 2 pre-computes distances using `sqrMagnitude` before sorting to cut O(n log n) sqrt calls to O(n). Fix 3 builds the consumable dictionary once at patch entry and threads it through the call chain, removing the per-container `CreateItemDictionary` + `HashSet` allocations.
+
+**Tech Stack:** C# / .NET 8, BepInEx 5, Harmony 2, xUnit (tests), Valheim Piece/Container/ZNetView APIs
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `AutoFeed.Core/FeedingLogic.cs` | Add `IsCacheValid` helper (enables unit tests for cache TTL logic) |
+| `AutoFeed.Tests/FeedingLogicTests.cs` | Add cache validity tests |
+| `Extensions/Vector3Extensions.cs` | Replace `Vector3.Distance` with `sqrMagnitude`; pre-compute sort distances; add cache params + read/write |
+| `Plugin.cs` | Add `ContainerCache` + `CacheTtl` config; update `GetContainersInRange` call site; build `consumableMap`; update `ContainersContainItemFromList` call site |
+| `Extensions/ContainerExtensions.cs` | Replace `List<ItemDrop>` param with `Dictionary<string, ItemDrop.ItemData>`; remove `CreateItemDictionary`; inline dict lookup in `TryFindMatchingItem` |
+
+---
+
+## Task 1: Add `IsCacheValid` to FeedingLogic and test it
+
+The cache timestamp check is pure logic — no Valheim types — so it belongs in `FeedingLogic.cs` where it can be unit-tested. Pattern mirrors `ShouldFeed`.
+
+**Files:**
+- Modify: `AutoFeed.Core/FeedingLogic.cs`
+- Modify: `AutoFeed.Tests/FeedingLogicTests.cs`
+
+- [ ] **Step 1: Write failing tests for `IsCacheValid`**
+
+Add to the bottom of `AutoFeed.Tests/FeedingLogicTests.cs`:
+
+```csharp
+// --- IsCacheValid ---
+
+[Fact]
+public void IsCacheValid_ReturnsTrue_WhenWithinTtl()
+{
+    Assert.True(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 4.9f, ttl: 5f));
+}
+
+[Fact]
+public void IsCacheValid_ReturnsFalse_WhenTtlExpired()
+{
+    Assert.False(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 5.1f, ttl: 5f));
+}
+
+[Fact]
+public void IsCacheValid_ReturnsFalse_WhenExactlyAtBoundary()
+{
+    Assert.False(FeedingLogic.IsCacheValid(cachedTimestamp: 0f, currentTime: 5f, ttl: 5f));
+}
+
+[Fact]
+public void IsCacheValid_ReturnsTrue_WhenCachedJustNow()
+{
+    Assert.True(FeedingLogic.IsCacheValid(cachedTimestamp: 10f, currentTime: 10f, ttl: 5f));
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --filter "IsCacheValid" -v minimal
+```
+
+Expected: compile error — `IsCacheValid` does not exist yet.
+
+- [ ] **Step 3: Add `IsCacheValid` to `FeedingLogic.cs`**
+
+Add after the `ShouldFeed` method in `AutoFeed.Core/FeedingLogic.cs`:
+
+```csharp
+/// <summary>
+/// Returns true if the cached value is still within the TTL window.
+/// </summary>
+public static bool IsCacheValid(float cachedTimestamp, float currentTime, float ttl) =>
+    currentTime - cachedTimestamp < ttl;
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj --filter "IsCacheValid" -v minimal
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Run full test suite — no regressions**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj -v minimal
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AutoFeed.Core/FeedingLogic.cs AutoFeed.Tests/FeedingLogicTests.cs
+git commit -m "feat: add IsCacheValid helper to FeedingLogic with tests"
+```
+
+---
+
+## Task 2: Fix 2 — Pre-compute distances in `GetContainersInRange`
+
+Replace `Vector3.Distance` (sqrt) with `sqrMagnitude` in both the range filter and the sort.
+
+**Files:**
+- Modify: `Extensions/Vector3Extensions.cs`
+
+- [ ] **Step 1: Replace the range check and sort in `Vector3Extensions.cs`**
+
+Current file content for reference (full method):
+
+```csharp
+public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange)
+{
+    var result = new List<Container>();
+    foreach (var piece in Piece.s_allPieces)
+    {
+        if (piece == null) continue;
+        var container = piece.GetComponent<Container>();
+        if (container == null) continue;
+        var dist = Vector3.Distance(piece.transform.position, center);
+        if (dist <= radiusRange && IsValidZNetView(container.GetComponent<ZNetView>()) && IsEligibleContainer(container))
+            result.Add(container);
+    }
+    result.Sort((a, b) => Vector3.Distance(a.transform.position, center).CompareTo(Vector3.Distance(b.transform.position, center)));
+    return result;
+}
+```
+
+Replace the **range check line** and the **sort** only (leave the signature and rest of the loop intact for now — the signature changes in Task 3):
+
+```csharp
+public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange)
+{
+    var sqrRadius = radiusRange * radiusRange;
+    var result = new List<Container>();
+    foreach (var piece in Piece.s_allPieces)
+    {
+        if (piece == null) continue;
+        var container = piece.GetComponent<Container>();
+        if (container == null) continue;
+        var sqrDist = (piece.transform.position - center).sqrMagnitude;
+        if (sqrDist <= sqrRadius && IsValidZNetView(container.GetComponent<ZNetView>()) && IsEligibleContainer(container))
+            result.Add(container);
+    }
+
+    var sorted = result
+        .Select(c => (container: c, sqrDist: (c.transform.position - center).sqrMagnitude))
+        .OrderBy(x => x.sqrDist)
+        .Select(x => x.container)
+        .ToList();
+
+    return sorted;
+}
+```
+
+- [ ] **Step 2: Verify project builds**
+
+```bash
+dotnet build AutoFeed.Core/AutoFeed.Core.csproj -v minimal 2>&1 | tail -5
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Extensions/Vector3Extensions.cs
+git commit -m "perf: replace Vector3.Distance with sqrMagnitude in container range/sort"
+```
+
+---
+
+## Task 3: Fix 1 — Add container cache to Plugin and update `GetContainersInRange`
+
+Wire up the cache: add the static dictionary and `CacheTtl` config to `Plugin.cs`, then update `GetContainersInRange` to accept `animalId`/`currentTime` and read/write the cache.
+
+**Files:**
+- Modify: `Plugin.cs`
+- Modify: `Extensions/Vector3Extensions.cs`
+
+- [ ] **Step 1: Add `ContainerCache` and `CacheTtl` to `Plugin.cs`**
+
+In `Plugin.cs`, add next to the existing `LastFeedTimes` declaration:
+
+```csharp
+internal static readonly Dictionary<int, (float timestamp, List<Container> containers)> ContainerCache = new();
+```
+
+Add `CacheTtl` config in the `Awake()` method, after the `ChestPrefix` binding:
+
+```csharp
+CacheTtl = Config.Bind(
+    "General",
+    "Container Cache TTL",
+    5f,
+    "Seconds before the nearby-container list is refreshed for each animal."
+);
+```
+
+Add the field declaration alongside `ContainerRange`, `ModEnabled`, `ChestPrefix`:
+
+```csharp
+public static ConfigEntry<float> CacheTtl = default!;
+```
+
+- [ ] **Step 2: Update `GetContainersInRange` signature to accept cache parameters**
+
+In `Extensions/Vector3Extensions.cs`, update the method signature and add cache logic at the top:
+
+```csharp
+public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange, int animalId, float currentTime)
+{
+    if (Plugin.ContainerCache.TryGetValue(animalId, out var entry)
+        && FeedingLogic.IsCacheValid(entry.timestamp, currentTime, Plugin.CacheTtl.Value))
+        return entry.containers;
+
+    var sqrRadius = radiusRange * radiusRange;
+    var result = new List<Container>();
+    foreach (var piece in Piece.s_allPieces)
+    {
+        if (piece == null) continue;
+        var container = piece.GetComponent<Container>();
+        if (container == null) continue;
+        var sqrDist = (piece.transform.position - center).sqrMagnitude;
+        if (sqrDist <= sqrRadius && IsValidZNetView(container.GetComponent<ZNetView>()) && IsEligibleContainer(container))
+            result.Add(container);
+    }
+
+    var sorted = result
+        .Select(c => (container: c, sqrDist: (c.transform.position - center).sqrMagnitude))
+        .OrderBy(x => x.sqrDist)
+        .Select(x => x.container)
+        .ToList();
+
+    Plugin.ContainerCache[animalId] = (currentTime, sorted);
+    return sorted;
+}
+```
+
+- [ ] **Step 3: Update the call site in `Plugin.cs` Postfix**
+
+The existing call (around line 76):
+
+```csharp
+var nearbyContainers =
+    ___m_character.gameObject.transform.position.GetContainersInRange(
+        ContainerRange.Value
+    );
+```
+
+Replace with:
+
+```csharp
+var nearbyContainers =
+    ___m_character.gameObject.transform.position.GetContainersInRange(
+        ContainerRange.Value, animalId, Time.time
+    );
+```
+
+Note: `animalId` is already declared earlier in the Postfix at the line `var animalId = ___m_character.GetInstanceID();` (this line exists in the current code and is unchanged). `Time.time` is already available via global usings.
+
+- [ ] **Step 4: Verify project builds**
+
+```bash
+dotnet build AutoFeed.Core/AutoFeed.Core.csproj -v minimal 2>&1 | tail -5
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 5: Run full test suite — no regressions**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj -v minimal
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Plugin.cs Extensions/Vector3Extensions.cs
+git commit -m "perf: add per-animal container scan cache with configurable TTL"
+```
+
+---
+
+## Task 4: Fix 3 — Thread consumable map through ContainerExtensions
+
+Replace the `List<ItemDrop>` → `CreateItemDictionary` pipeline with a `Dictionary<string, ItemDrop.ItemData>` passed from patch entry, eliminating per-container allocations.
+
+**Files:**
+- Modify: `Extensions/ContainerExtensions.cs`
+- Modify: `Plugin.cs`
+
+- [ ] **Step 1: Rewrite `ContainerExtensions.cs`**
+
+Replace the entire file content:
+
+```csharp
+namespace AutoFeed;
+
+public static class ContainerExtensions
+{
+    public static bool ContainersContainItemFromList(
+        this List<Container> containers,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
+        out Container? targetContainer,
+        out ItemDrop.ItemData? targetItem
+    ) =>
+        FindItemInContainers(containers, consumableMap, out targetContainer, out targetItem);
+
+    private static bool FindItemInContainers(
+        List<Container> containers,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
+        out Container? targetContainer,
+        out ItemDrop.ItemData? targetItem
+    )
+    {
+        foreach (var container in containers)
+        {
+            var items = container.GetInventory().GetAllItems();
+            if (TryFindMatchingItem(items, consumableMap, out targetItem))
+            {
+                targetContainer = container;
+                return true;
+            }
+        }
+
+        targetContainer = null;
+        targetItem = null;
+        return false;
+    }
+
+    private static bool TryFindMatchingItem(
+        List<ItemDrop.ItemData> items,
+        Dictionary<string, ItemDrop.ItemData> consumableMap,
+        out ItemDrop.ItemData? targetItem
+    )
+    {
+        foreach (var item in items)
+            if (consumableMap.TryGetValue(item.m_shared.m_name, out var match))
+            {
+                targetItem = match;
+                return true;
+            }
+        targetItem = null;
+        return false;
+    }
+}
+```
+
+- [ ] **Step 2: Update the call site in `Plugin.cs` Postfix**
+
+In the Postfix, add `consumableMap` build just before the `GetContainersInRange` call (or anywhere before `ContainersContainItemFromList`):
+
+```csharp
+var consumableMap = ___m_consumeItems
+    .ToDictionary(i => i.m_itemData.m_shared.m_name, i => i.m_itemData);
+```
+
+Then update the `ContainersContainItemFromList` call:
+
+```csharp
+var foundContainerWithFood = nearbyContainers.ContainersContainItemFromList(
+    consumableMap,
+    out var container,
+    out var item
+);
+```
+
+The old call (currently around line 80–84 in `Plugin.cs`) looks like:
+
+```csharp
+var foundContainerWithFood = nearbyContainers.ContainersContainItemFromList(
+    ___m_consumeItems,
+    out var container,
+    out var item
+);
+```
+
+Replace it with the new call above (passing `consumableMap` instead of `___m_consumeItems`).
+
+- [ ] **Step 3: Verify project builds**
+
+```bash
+dotnet build AutoFeed.Core/AutoFeed.Core.csproj -v minimal 2>&1 | tail -5
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 4: Run full test suite — no regressions**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj -v minimal
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Extensions/ContainerExtensions.cs Plugin.cs
+git commit -m "perf: build consumable map once at patch entry, thread through call chain"
+```
+
+---
+
+> **Note on test coverage:** `GetContainersInRange` cache hit/miss behaviour cannot be unit tested — it depends on Valheim types (`Container`, `Piece`, `ZNetView`) that are unavailable outside the game runtime. The `IsCacheValid` tests in Task 1 cover the TTL logic in isolation, which is the only pure-C# piece of the cache. Integration verification happens by running the mod on the server.
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite one final time**
+
+```bash
+dotnet test AutoFeed.Tests/AutoFeed.Tests.csproj -v normal
+```
+
+Expected: all tests pass, no warnings about missing references.
+
+- [ ] **Step 2: Verify build is clean**
+
+```bash
+dotnet build AutoFeed.Core/AutoFeed.Core.csproj -v minimal 2>&1
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`

--- a/docs/superpowers/specs/2026-04-01-performance-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-01-performance-fixes-design.md
@@ -1,0 +1,72 @@
+# AutoFeed Performance Fixes — Design Spec
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Problem
+
+The `UpdateConsumeItem` Harmony postfix fires repeatedly per tamed animal. Three hotspots cause frame drops as the world scales:
+
+1. `GetContainersInRange` iterates every piece in `Piece.s_allPieces` with multiple `GetComponent` calls per piece — O(n) per animal per tick.
+2. The sort comparator recalculates `Vector3.Distance` (involves `sqrt`) for both sides of every comparison — O(n log n) `sqrt` calls instead of O(n).
+3. `CreateItemDictionary` and a `HashSet<string>` are heap-allocated on every feed check, creating GC pressure.
+
+## Fix 1 — Per-Animal Container Scan Cache
+
+**Location:** `Plugin.cs` + `Vector3Extensions.cs`
+
+Add a static cache to `Plugin`:
+
+```csharp
+internal static readonly Dictionary<int, (float timestamp, List<Container> containers)> ContainerCache = new();
+```
+
+Keyed by animal `GetInstanceID()`. Add a `CacheTtl` `ConfigEntry<float>` (default `5f` seconds).
+
+In `GetContainersInRange`, accept the animal ID and current time. If a cache entry exists and `currentTime - timestamp < CacheTtl`, return the cached list. Otherwise perform the scan, store the result, and return it.
+
+Cache entries for dead animals expire naturally after `CacheTtl` without explicit cleanup.
+
+## Fix 2 — Pre-Compute Distances Before Sorting
+
+**Location:** `Vector3Extensions.cs`
+
+Replace the sort comparator with a pre-computation step:
+
+1. After building `result`, compute `(container, sqrMagnitude)` pairs once.
+2. Sort by pre-computed `sqrMagnitude`.
+3. Project back to `List<Container>`.
+
+Also replace `Vector3.Distance` in the range check with `(piece.transform.position - center).sqrMagnitude <= radiusRange * radiusRange` to eliminate `sqrt` from the scan loop entirely.
+
+## Fix 3 — Build Consumable HashSet Once at Patch Entry
+
+**Location:** `Plugin.cs` + `ContainerExtensions.cs`
+
+In `UpdateConsumeItemPatch.Postfix`, build `HashSet<string> consumableNames` once from `___m_consumeItems`:
+
+```csharp
+var consumableNames = new HashSet<string>(___m_consumeItems.Select(i => i.m_itemData.m_shared.m_name));
+```
+
+Pass `consumableNames` through the call chain:
+
+- `ContainersContainItemFromList(containers, consumableNames, out container, out item)`
+- `FindItemInContainers` → `TryFindMatchingItem`
+
+Remove `CreateItemDictionary` entirely. `TryFindMatchingItem` uses `consumableNames` (HashSet) to find the matching name, then retrieves the `ItemData` by looking it up in the original `___m_consumeItems` list (passed through or re-queried). This eliminates the `Dictionary<string, List<ItemDrop.ItemData>>` allocation and the per-container `HashSet` reconstruction.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `Plugin.cs` | Add `ContainerCache`, `CacheTtl` config; build `consumableNames` at patch entry; pass animal ID + time to range query |
+| `Extensions/Vector3Extensions.cs` | Accept cache parameters; add sqrMagnitude range check; pre-compute sort distances |
+| `Extensions/ContainerExtensions.cs` | Replace `CreateItemDictionary` with `HashSet<string>` parameter; remove dictionary allocation |
+
+## What Is Not Changing
+
+- `FeedingLogic.cs` — `FindConsumableInInventory` already accepts `HashSet<string>`, no changes needed
+- `MonsterAIExtensions.cs` — feed execution path is not a hotspot
+- `PluginSettings.cs` — `FeedInterval` remains unchanged; `CacheTtl` is a new `ConfigEntry` in `Plugin.cs`
+- All existing tests remain valid; new tests for cache behavior should be added in `AutoFeed.Tests`

--- a/docs/superpowers/specs/2026-04-01-performance-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-01-performance-fixes-design.md
@@ -9,11 +9,11 @@ The `UpdateConsumeItem` Harmony postfix fires repeatedly per tamed animal. Three
 
 1. `GetContainersInRange` iterates every piece in `Piece.s_allPieces` with multiple `GetComponent` calls per piece — O(n) per animal per tick.
 2. The sort comparator recalculates `Vector3.Distance` (involves `sqrt`) for both sides of every comparison — O(n log n) `sqrt` calls instead of O(n).
-3. `CreateItemDictionary` and a `HashSet<string>` are heap-allocated on every feed check, creating GC pressure.
+3. `CreateItemDictionary` and a `HashSet<string>` are heap-allocated on every feed check per container, creating GC pressure.
 
 ## Fix 1 — Per-Animal Container Scan Cache
 
-**Location:** `Plugin.cs` + `Vector3Extensions.cs`
+**Location:** `Plugin.cs` + `Extensions/Vector3Extensions.cs`
 
 Add a static cache to `Plugin`:
 
@@ -23,50 +23,115 @@ internal static readonly Dictionary<int, (float timestamp, List<Container> conta
 
 Keyed by animal `GetInstanceID()`. Add a `CacheTtl` `ConfigEntry<float>` (default `5f` seconds).
 
-In `GetContainersInRange`, accept the animal ID and current time. If a cache entry exists and `currentTime - timestamp < CacheTtl`, return the cached list. Otherwise perform the scan, store the result, and return it.
+Unity's `GetInstanceID()` returns a unique integer per object instance for the lifetime of the scene; dead animals are destroyed and their IDs are not reused. The cache will remain bounded to the number of animals that have been fed during the session and requires no explicit cleanup.
 
-Cache entries for dead animals expire naturally after `CacheTtl` without explicit cleanup.
+Update `GetContainersInRange` signature to accept animal ID and current time:
+
+```csharp
+public static List<Container> GetContainersInRange(this Vector3 center, float radiusRange, int animalId, float currentTime)
+```
+
+If `Plugin.ContainerCache.TryGetValue(animalId, out var entry)` and `currentTime - entry.timestamp < Plugin.CacheTtl.Value`, return `entry.containers`. Otherwise perform the scan **including the distance pre-computation sort from Fix 2**, store `(currentTime, sortedResult)` in the cache, and return it. The cache stores the already-sorted list so cache hits skip sorting entirely.
+
+The call site in `UpdateConsumeItemPatch.Postfix` becomes:
+
+```csharp
+var nearbyContainers = ___m_character.gameObject.transform.position
+    .GetContainersInRange(ContainerRange.Value, animalId, Time.time);
+```
 
 ## Fix 2 — Pre-Compute Distances Before Sorting
 
-**Location:** `Vector3Extensions.cs`
+**Location:** `Extensions/Vector3Extensions.cs`
 
 Replace the sort comparator with a pre-computation step:
 
-1. After building `result`, compute `(container, sqrMagnitude)` pairs once.
+1. After building `result`, compute `(container, sqrMagnitude)` pairs once into a local list.
 2. Sort by pre-computed `sqrMagnitude`.
 3. Project back to `List<Container>`.
 
 Also replace `Vector3.Distance` in the range check with `(piece.transform.position - center).sqrMagnitude <= radiusRange * radiusRange` to eliminate `sqrt` from the scan loop entirely.
 
-## Fix 3 — Build Consumable HashSet Once at Patch Entry
+## Fix 3 — Build Consumable Map Once at Patch Entry
 
-**Location:** `Plugin.cs` + `ContainerExtensions.cs`
+**Location:** `Plugin.cs` + `Extensions/ContainerExtensions.cs`
 
-In `UpdateConsumeItemPatch.Postfix`, build `HashSet<string> consumableNames` once from `___m_consumeItems`:
+In `UpdateConsumeItemPatch.Postfix`, build a `Dictionary<string, ItemDrop.ItemData>` once from `___m_consumeItems`:
 
 ```csharp
-var consumableNames = new HashSet<string>(___m_consumeItems.Select(i => i.m_itemData.m_shared.m_name));
+var consumableMap = ___m_consumeItems
+    .ToDictionary(i => i.m_itemData.m_shared.m_name, i => i.m_itemData);
 ```
 
-Pass `consumableNames` through the call chain:
+Multiple consumables with the same name are not expected in Valheim; taking one `ItemData` per name is correct. The call site in `UpdateConsumeItemPatch.Postfix` changes to:
 
-- `ContainersContainItemFromList(containers, consumableNames, out container, out item)`
-- `FindItemInContainers` → `TryFindMatchingItem`
+```csharp
+var foundContainerWithFood = nearbyContainers.ContainersContainItemFromList(
+    consumableMap,
+    out var container,
+    out var item
+);
+```
 
-Remove `CreateItemDictionary` entirely. `TryFindMatchingItem` uses `consumableNames` (HashSet) to find the matching name, then retrieves the `ItemData` by looking it up in the original `___m_consumeItems` list (passed through or re-queried). This eliminates the `Dictionary<string, List<ItemDrop.ItemData>>` allocation and the per-container `HashSet` reconstruction.
+Pass `consumableMap` through the entire call chain:
+
+```
+ContainersContainItemFromList(containers, consumableMap, out container, out item)
+  → FindItemInContainers(containers, consumableMap, ...)
+    → TryFindMatchingItem(items, consumableMap, ...)
+```
+
+Full updated signatures for `ContainerExtensions.cs`:
+
+```csharp
+public static bool ContainersContainItemFromList(
+    this List<Container> containers,
+    Dictionary<string, ItemDrop.ItemData> consumableMap,
+    out Container? targetContainer,
+    out ItemDrop.ItemData? targetItem)
+
+private static bool FindItemInContainers(
+    List<Container> containers,
+    Dictionary<string, ItemDrop.ItemData> consumableMap,
+    out Container? targetContainer,
+    out ItemDrop.ItemData? targetItem)
+
+private static bool TryFindMatchingItem(
+    List<ItemDrop.ItemData> items,
+    Dictionary<string, ItemDrop.ItemData> consumableMap,
+    out ItemDrop.ItemData? targetItem)
+{
+    foreach (var item in items)
+        if (consumableMap.TryGetValue(item.m_shared.m_name, out var match))
+        {
+            targetItem = match;
+            return true;
+        }
+    targetItem = null;
+    return false;
+}
+```
+
+Remove `CreateItemDictionary` entirely. The existing `HashSet<string>` allocation inside `TryFindMatchingItem` is also removed — direct dictionary lookup replaces it.
+
+This eliminates:
+- `CreateItemDictionary` (removed entirely)
+- The `new HashSet<string>(itemDropDict.Keys)` allocation per container
+- The call to `FeedingLogic.FindConsumableInInventory` (replaced by inline dict lookup)
+
+`FeedingLogic.FindConsumableInInventory` is not changed — it remains used by unit tests.
 
 ## Affected Files
 
 | File | Change |
 |------|--------|
-| `Plugin.cs` | Add `ContainerCache`, `CacheTtl` config; build `consumableNames` at patch entry; pass animal ID + time to range query |
-| `Extensions/Vector3Extensions.cs` | Accept cache parameters; add sqrMagnitude range check; pre-compute sort distances |
-| `Extensions/ContainerExtensions.cs` | Replace `CreateItemDictionary` with `HashSet<string>` parameter; remove dictionary allocation |
+| `Plugin.cs` | Add `ContainerCache`, `CacheTtl` config; build `consumableMap` at patch entry; pass `animalId` + `Time.time` to `GetContainersInRange`; pass `consumableMap` to `ContainersContainItemFromList` |
+| `Extensions/Vector3Extensions.cs` | Add `animalId` + `currentTime` params; add cache read/write; replace `Vector3.Distance` with `sqrMagnitude`; pre-compute sort distances |
+| `Extensions/ContainerExtensions.cs` | Replace `List<ItemDrop>` param with `Dictionary<string, ItemDrop.ItemData>`; remove `CreateItemDictionary`; inline dict lookup in `TryFindMatchingItem` |
 
 ## What Is Not Changing
 
-- `FeedingLogic.cs` — `FindConsumableInInventory` already accepts `HashSet<string>`, no changes needed
-- `MonsterAIExtensions.cs` — feed execution path is not a hotspot
-- `PluginSettings.cs` — `FeedInterval` remains unchanged; `CacheTtl` is a new `ConfigEntry` in `Plugin.cs`
-- All existing tests remain valid; new tests for cache behavior should be added in `AutoFeed.Tests`
+- `AutoFeed.Core/FeedingLogic.cs` — `FindConsumableInInventory` and `ShouldFeed` unchanged
+- `Extensions/MonsterAIExtensions.cs` — feed execution path is not a hotspot
+- `PluginSettings.cs` — `FeedInterval` unchanged; `CacheTtl` is a new `ConfigEntry` in `Plugin.cs`
+- All existing tests remain valid; new tests for cache hit/miss behavior should be added in `AutoFeed.Tests/FeedingLogicTests.cs` (or a new `ContainerCacheTests.cs`), covering: cache hit returns same list, cache miss after TTL expiry, and different animal IDs produce independent cache entries


### PR DESCRIPTION
## Summary

- Per-animal container scan cache (5s TTL) eliminates full `Piece.s_allPieces` scan on every AI tick
- `sqrMagnitude` replaces `Vector3.Distance` in range check and sort, removing redundant sqrt calls
- Consumable map built once per feed attempt instead of once per container, reducing GC pressure
- Fix: filter destroyed containers from cache hits to prevent `MissingReferenceException`
- Fix: duplicate-safe consumable map build (`ContainsKey` guard, net48 compatible)
- Bumps version to 1.0.1

## Test Plan

- [x] 16/16 unit tests passing
- [x] Deployed and verified on YapperHeim dedicated server

🤖 Generated with [Claude Code](https://claude.ai/code)