### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Documentation: Incorrect tags on the mod in Thunderstore showing server-side when this is a client and server required mod as of 1.0.0
+
 ## 1.0.1
 
 - Performance: container scan results are now cached per animal (configurable TTL, default 5s), eliminating the full `Piece.s_allPieces` scan on every AI tick


### PR DESCRIPTION
## Summary
- Bump version to 1.0.2 in `AutoFeed.csproj`
- Add 1.0.2 changelog entry (Thunderstore tag fix)

## Test plan
- [ ] CI tests pass
- [ ] After merge, push `v1.0.2` tag to trigger release workflow
- [ ] Run `bash Scripts/package.sh` locally and upload to Thunderstore