### PR TITLE
chore: bump csproj version to 1.0.2

### DIFF
--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Narolith.AutoFeed</AssemblyName>
     <Title>Auto Feed</Title>
     <Description>Valheim mod to auto feed animals from a nearby chest</Description>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary

- PR #17 bumped `CHANGELOG.md` to 1.0.2 but missed `AutoFeed.csproj`
- Fixes the version mismatch so the packaging script produces the correct zip name and embedded version