### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/AutoFeed.csproj
+++ b/AutoFeed.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Narolith.AutoFeed</AssemblyName>
     <Title>Auto Feed</Title>
     <Description>Valheim mod to auto feed animals from a nearby chest</Description>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Documentation: Fixed README incorrectly stating server-only installation; mod requires both server and client
+
 ## 1.0.2
 
 - Documentation: Incorrect tags on the mod in Thunderstore showing server-side when this is a client and server required mod as of 1.0.0


### PR DESCRIPTION
## Summary

- Bump version to 1.0.3
- CHANGELOG entry for README installation fix (server + client required)